### PR TITLE
Fix compile error on big sur

### DIFF
--- a/idb_companion/Server/FBIDBServiceHandler.mm
+++ b/idb_companion/Server/FBIDBServiceHandler.mm
@@ -97,7 +97,7 @@ static Status drain_writer(FBFuture<FBTask<NSNull *, NSInputStream *, id> *> *ta
     }
     T response;
     idb::Payload *payload = response.mutable_payload();
-    payload->set_data(buffer, size);
+    payload->set_data(reinterpret_cast<void *>(buffer), size);
     stream->Write(response);
   }
   [inputStream close];


### PR DESCRIPTION
/idb/idb_companion/Server/FBIDBServiceHandler.mm:100:14: error: no matching member function for call to 'set_data'
    payload->set_data(buffer, size);
    ~~~~~~~~~^~~~~~~~

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/master/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix compile error mentioned at https://github.com/facebook/idb/issues/671.



